### PR TITLE
Twilio Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,5 @@ pythonenv3.8/
 .dmypy.json
 dmypy.json
 
-
+PRIVATE_KEY.json
+nexmo_private.key

--- a/example-env
+++ b/example-env
@@ -6,6 +6,10 @@ GOOGLE_CLIENT_ID="YOUR_GOOGLE_AUTH_CLIENT_ID"
 #Firebase - Firestore
 FIREBASE_PRIVATE_KEY="./PRIVATE_KEY.json"
 
+#Communication API Preferences
+#Set to "True" if you would like to use Twilio for SMS/calls or "False" for Nexmo
+USE_TWILIO="True"
+
 #NEXMO
 #Application id and private key are used to generate JWT for the voice api
 NEXMO_APPLICATION_ID="NEXMO_APPLICATION_ID"
@@ -15,13 +19,17 @@ NEXMO_API_KEY="NEXMO_API_KEY"
 NEXMO_API_SECRET="NEXMO_API_SECRET"
 NEXMO_NUMBER="NEXMO_VIRTUAL_NUMBER"
 
+TWILIO_ACCOUNT_SID="TWILIO_ACCOUNT_SID"
+TWILIO_AUTH_TOKEN="TWILIO_AUTH_TOKEN"
+TWILIO_NUMBER="TWILIO_NUMBER"
+
 #For App purposes
 SITE_URL="https://domain.ext"
 #Aplication ping is 30 seconds. If a call is done then wait a time after call the same number again
 WAIT_AFTER_CALL="120"
 #When the number of failed pings is 60 send a sms to customer / 60 is the equal to 1 hour of intents
 #Of course, you can change this parameter as you wish
-NEXMO_FAILED_PING_SMS="60"
+NIGHTSCOUT_FAILED_PING_SMS="60"
 
 # If after X seconds NIGHTSCOUT entries still not updating  sms is sent to user notifying about$
 NIGHTSCOUT_NOT_UPDATE_SECONDS = "1800"

--- a/models.py
+++ b/models.py
@@ -1,3 +1,4 @@
+
 # Load Firebase configuration
 from firebase_admin import firestore
 import firebase_admin

--- a/notifier.py
+++ b/notifier.py
@@ -312,7 +312,7 @@ def call_glucose_alert(to, glucose):
             return True
     else:
         call = client.calls.create(
-                        twiml='<Response><Say>Alert Your Blood Glucose is {0}</Say></Response>'.format('65'),
+                        twiml='<Response><Say>Alert Your Blood Glucose is {0}</Say></Response>'.format(glucose),
                         to=to,
                         from_=os.getenv("TWILIO_NUMBER")
                     )
@@ -412,7 +412,12 @@ def events():
     return "Event Received"
 
 # Twilio webhooks
+@app.route('/webhooks/twilio-inbound-messages', methods=["POST", "GET"])
+def incoming_sms():
+    body = request.values.get('Body', '')
 
+    return "Event Received"
+    
 # Schedule Logic
 
 

--- a/notifier.py
+++ b/notifier.py
@@ -596,3 +596,6 @@ print("Nightscout-Nexmo Thread starts")
 atexit.register(on_shutdown)
 
 ##call_glucose_alert('14049561232', 50)
+##handle_nightscout_failed_update('14049561232', 'test.com', 'vmalepati1')
+##sms_glucose_alert('14049561232', 'vmalepati1', 65)
+##sms_request_glucose_level_twilio('NIGHTSCOUT', '14049561232', 65)

--- a/notifier.py
+++ b/notifier.py
@@ -36,7 +36,7 @@ with app.app_context():
 # enable cors
 cors = CORS(app)
 # define secret_key to flask app to manage sessions
-app.secret_key = b'_5#y2L"F4Q8z\n\xec]/'
+app.secret_key = b'su\xdb\xf2\x94hK\x81J\x8c\xf7\x1e\xfb\x81F\xf1'
 
 # load environment
 envpath = join(dirname(__file__), "./.env")
@@ -181,7 +181,7 @@ def handle_nightscout_failed_pings(to, api_url, username):
                 "message": {
                     "content": {
                         "type": "text",
-                        "text": "Dear {0} the nexmo api url: {1} is not responding, please check the service".format(username, api_url)
+                        "text": "Dear {0} the Nightscout api url: {1} is not responding, please check the service".format(username, api_url)
                     }
                 }
             }
@@ -480,7 +480,7 @@ if __name__ == "notifier":
     signal.signal(signal.SIGINT, signal_handler)
     # run job at second 30 of each minute
     schedule.every().minute.at(':30').do(job, str(uuid.uuid4()))
-    # update scouts each our at minute 00
+    # update scouts each hour at minute 00
     schedule.every().hour.at(':00').do(refresh_scouts, str(uuid.uuid4()))
     thread = Process(target=run_schedule)
     thread.start()

--- a/notifier.py
+++ b/notifier.py
@@ -126,31 +126,40 @@ def handle_nightscout_failed_update(to, api_url, username):
         nightscout_failed_update_wait_mark[to] += 1
 
     if nightscout_failed_update_wait_mark[to] == 1:
-        response = requests.post(
-            'https://api.nexmo.com/v0.1/messages',
-            auth=HTTPBasicAuth(os.getenv("NEXMO_API_KEY"),
-                               os.getenv("NEXMO_API_SECRET")),
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "application/json"
-            },
-            json={
-                "from": {
-                    "type": "sms",
-                    "number": os.getenv("NEXMO_NUMBER"),
+        if not env_flag('USE_TWILIO'):
+            response = requests.post(
+                'https://api.nexmo.com/v0.1/messages',
+                auth=HTTPBasicAuth(os.getenv("NEXMO_API_KEY"),
+                                   os.getenv("NEXMO_API_SECRET")),
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
                 },
-                "to": {
-                    "type": "sms",
-                    "number": to
-                },
-                "message": {
-                    "content": {
-                        "type": "text",
-                        "text": "Dear {0} the nightscout api is not retrieving updated entries, please check your device or your service to solve any issues".format(username)
+                json={
+                    "from": {
+                        "type": "sms",
+                        "number": os.getenv("NEXMO_NUMBER"),
+                    },
+                    "to": {
+                        "type": "sms",
+                        "number": to
+                    },
+                    "message": {
+                        "content": {
+                            "type": "text",
+                            "text": "Dear {0} the nightscout api is not retrieving updated entries, please check your device or your service to solve any issues".format(username)
+                        }
                     }
                 }
-            }
-        ).json()
+            ).json()
+        else:
+            message = client.messages \
+                .create(
+                     body="Dear {0} the nightscout api is not retrieving updated entries, please check your device or your service to solve any issues".format(username),
+                     from_=os.getenv("TWILIO_NUMBER"),
+                     to=to
+                 )
+                        
     elif nightscout_failed_update_wait_mark[to] == int(os.getenv("WAIT_AFTER_SMS_MARK")):
         nightscout_failed_update_wait_mark[to] = 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,6 @@ six==1.14.0
 uritemplate==3.0.1
 urllib3==1.25.8
 Werkzeug==0.16.1
+env_flag==2.1.0
+twilio==6.60.0
+APScheduler==3.7.0


### PR DESCRIPTION
Added support for Twilio, and the communication API preference (Nexmo or Twilio) can be configured in the .env file.

Summary of changes:
- Added PRIVATE_KEY.json and nexmo_private.key to gitignore
- Switched from using a multiprocessing thread + schedule module to using the asynchronous APScheduler module for the overall thread loop. This allows for compatibility with windows systems because starting a multiprocessing process requires an `if __name__ == '__main__'` guard which won't evaluate to True when running notifier.py from gunicorn or `flask run`
- Added Twilio support for both SMS/calling with separate webhook endpoints apart from Nexmo. Only one webhook (`/webhooks/twilio-inbound-messages`) needs to be configured in the [Twilio console](https://www.twilio.com/console). `/webhooks/twilio-on-completed` is programmatically set as a callback when queueing a call.
- Added new variables in .env for Twilio API authentication info and a flag `USE_TWILIO` to configure between Nexmo and Twilio
- Updated requirements.txt with new modules