### PR TITLE
Update README and tutorial_en with how to use Twilio

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For the `firebase secrets json` file just put the content in a single line. Copy
   "client_x509_cert_url": "xxxxx"
 }
 ```
+You may configure whether you want to use the Vonage API or the Twilio API using the `USE_TWILIO` field.
 
 When clicking on the the deploy button:
 

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
-    "name": "Heroku: ns-notifier",
-    "description": "A Flask App that send sms alerts about glucose level to your family or friends.",
+    "name": "Heroku: ScoutX",
+    "description": "Notify your emergency contacts in case your blood glucose levels are out of range!",
     "image": "heroku/python",
-    "repository": "https://github.com/nexmo-community/nexmo-scout",
+    "repository": "repository": "https://github.com/alphacentauri82/scoutx",
     "keywords": ["python", "flask" ],
     "env": {
       "GOOGLE_CLIENT_ID": {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
     "name": "Heroku: ScoutX",
     "description": "Notify your emergency contacts in case your blood glucose levels are out of range!",
     "image": "heroku/python",
-    "repository": "repository": "https://github.com/alphacentauri82/scoutx",
+    "repository": "https://github.com/alphacentauri82/scoutx",
     "keywords": ["python", "flask" ],
     "env": {
       "GOOGLE_CLIENT_ID": {

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
-    "name": "Heroku: scoutx",
+    "name": "Heroku: ns-notifier",
     "description": "A Flask App that send sms alerts about glucose level to your family or friends.",
     "image": "heroku/python",
-    "repository": "https://github.com/alphacentauri82/scoutx",
+    "repository": "https://github.com/nexmo-community/nexmo-scout",
     "keywords": ["python", "flask" ],
     "env": {
       "GOOGLE_CLIENT_ID": {
@@ -11,20 +11,38 @@
       "FIREBASE_PRIVATE_KEY": {
           "description":"A json file with the firebase credentials."
       },
+      "USE_TWILIO": {
+          "description": "Set to True if you would like to use Twilio for SMS/calls or False for Vonage"
+      },
       "NEXMO_APPLICATION_ID": {
-          "description": "The application id, get this in the vonage dashboard > in the application settings."
+          "description": "The application id, get this in the vonage dashboard for nexmo > inside the application settings."
       },
       "NEXMO_PRIVATE_KEY": {
-        "description": "The private key path, you can download this in the vonage dashboard > in the application settings"
+        "description": "The private key path, you can download this in the vonage dashboard for nexmo > inside the application settings"
       },
       "NEXMO_API_KEY": {
-          "description": "The nexmo api key. Available in the user settings section on the vonage dashboard"
+          "description": "The nexmo api key. Available in the user settings section on the vonage dashboard for nexmo"
       },
       "NEXMO_API_SECRET": {
-          "description": "The api secret, also available in the user settings section on the vonage dashboard"
+          "description": "The api secret, also available in the user settings section on the vonage dashboard for nexmo"
       },
       "NEXMO_NUMBER": {
           "description": "Your nexmo number"
+      },
+      "NEXMO_WHATSAPP_NUMBER": {
+          "description": "Your nexmo WhatsApp number. This can be the default sandbox number 14157386170 or a WhatsApp business number that has been configured through Messages and Dispatch > Social Channels"
+      },
+      "TWILIO_ACCOUNT_SID": {
+          "description": "The Twilio account SID. Available in the project info section of the Twilio console"
+      },
+      "TWILIO_AUTH_TOKEN": {
+          "description": "The Twilio auth token, also available in the project info section of the Twilio console"
+      },
+      "TWILIO_NUMBER": {
+          "description": "Your Twilio number. You can find this in the Phone Numbers tab of the Twilio console"
+      },
+      "TWILIO_WHATSAPP_NUMBER": {
+          "description": "Your Twilio WhatsApp number. This can be the default sandbox number 14155238886 or a Twilio number that has been enabled for WhatsApp through the Programmable Messaging tab > Sender Pool"
       },
       "SITE_URL": {
           "description": "Your heroku main url"
@@ -37,5 +55,5 @@
           "description": "When the number of failed pings is 60 send a sms to customer",
           "value": "60"
       }
-    }
-  }
+	}
+}


### PR DESCRIPTION
Added info to the `README` and `tutorial_en` regarding how to use Twilio as a communication API.

Summary of changes:
- Explained the option to select either Vonage or Twilio as a communication API
- Added instructions for using Twilio as the communication API
- Updated app.json to include the most recent `.env` variables